### PR TITLE
fix(tests): let test with miri pass

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -310,6 +310,9 @@ mod tests {
 
     use core::mem::{transmute, MaybeUninit};
 
+    #[repr(C, align(32))]
+    struct Aligned<T>(T);
+
     struct Stack<'a> {
         idx: usize,
         stack: &'a mut [u8],
@@ -357,8 +360,8 @@ mod tests {
 
     #[test]
     fn stack() {
-        let mut stack = [1u8; 16];
-        let stack = stack.as_mut();
+        let mut stack = Aligned([1u8; 16]);
+        let stack = stack.0.as_mut();
         let mut sp = Stack::new(stack);
         sp.push(16usize);
         sp.push(&[1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8, 8u8][..]);
@@ -370,8 +373,8 @@ mod tests {
 
     #[test]
     fn stack_slice() {
-        let mut stack = [1u8; 16];
-        let stack = stack.as_mut();
+        let mut stack = Aligned([1u8; 16]);
+        let stack = stack.0.as_mut();
         let mut sp = Stack::new(stack);
         sp.push(&b"Hello World"[..]);
         assert_eq!(
@@ -382,8 +385,8 @@ mod tests {
 
     #[test]
     fn stack_unaligned() {
-        let mut stack = [0xFFu8; 24];
-        let stack = stack.as_mut();
+        let mut stack = Aligned([0xFFu8; 24]);
+        let stack = stack.0.as_mut();
         let mut sp = Stack::new(stack);
         sp.push(1u8);
         sp.push(2usize);
@@ -400,8 +403,8 @@ mod tests {
 
     #[test]
     fn stack_pop() {
-        let mut stack = [1u8; 16];
-        let stack = stack.as_mut();
+        let mut stack = Aligned([1u8; 16]);
+        let stack = stack.0.as_mut();
         {
             let mut sp = Stack::new(stack);
             sp.push(16usize);
@@ -417,8 +420,8 @@ mod tests {
     #[test]
     #[should_panic]
     fn stack_underflow() {
-        let mut stack = [1u8; 16];
-        let stack = stack.as_mut();
+        let mut stack = Aligned([1u8; 16]);
+        let stack = stack.0.as_mut();
         {
             let mut sp = Stack::new(stack);
             sp.push(16usize);
@@ -436,8 +439,8 @@ mod tests {
     #[test]
     #[should_panic]
     fn stack_overflow() {
-        let mut stack = [1u8; 16];
-        let stack = stack.as_mut();
+        let mut stack = Aligned([1u8; 16]);
+        let stack = stack.0.as_mut();
         {
             let mut sp = Stack::new(stack);
             sp.push(16usize);
@@ -449,9 +452,6 @@ mod tests {
     #[test]
     fn stack_alignment() {
         // Prepare the crt0 stack.
-        #[repr(C, align(32))]
-        struct Aligned<T>(T);
-
         let mut aligned = Aligned([0u8; 1024]);
         let mut error = false;
         for i in 0..32 {


### PR DESCRIPTION
Fix initial stack alignment, so that
`cargo +nightly miri test -- stack`
passes.

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
