### PR TITLE
fix(tests): ignore reader::tests::real when testing with miri

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -337,6 +337,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn real() {
         let reader = Reader::from_environ().prev().prev();
         assert_eq!(reader.count(), std::env::args().count());


### PR DESCRIPTION
When testing with miri [1], the `reader::tests::real` test enters
undefined behaviour by accessing memory before `environ`,
which is undefined memory for the miri interpreter.

[1]: `cargo +nightly miri test -- reader`

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
