### PR TITLE
support AT_SYSINFO and AT_SYSINFO_EHDR on all architectures

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -224,11 +224,7 @@ impl<'a> Iterator for Reader<'a, Aux> {
             AT_RANDOM => Entry::Random(unsafe { *(val as *const [u8; 16]) }),
             AT_HWCAP2 => Entry::HwCap2(val),
             AT_EXECFN => Entry::ExecFilename(unsafe { u2s(val).ok()? }),
-
-            #[cfg(target_arch = "x86")]
             AT_SYSINFO => Entry::SysInfo(val),
-
-            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
             AT_SYSINFO_EHDR => Entry::SysInfoEHdr(val),
 
             _ => {


### PR DESCRIPTION
Not sure why AT_SYSINFO and AT_SYSINFO_EHDR were limited to x86 and x86/x86_64 respectively.

Linux sets AT_SYSINFO on ia64 and x86 and AT_SYSINFO_EHDR on all architectures.

Removing the the architecture guard on AT_SYSINFO is harmless as the identifier (32) is not reused on other architectures, so the code will work correctly without an architecture guard.